### PR TITLE
latency problem solved

### DIFF
--- a/app.py
+++ b/app.py
@@ -74,4 +74,4 @@ def get_data():
 
 
 if __name__ == "__main__":
-    app.run(host='0.0.0.0',port=5000,debug=True)
+    app.run(host='0.0.0.0',port=8080, debug=True, threaded=True)


### PR DESCRIPTION
"On operating systems that support ipv6 and have it configured such as modern Linux systems, OS X 10.4 or higher as well as Windows Vista some browsers can be painfully slow if accessing your local server. The reason for this is that sometimes “localhost” is configured to be available on both ipv4 and ipv6 socktes and some browsers will try to access ipv6 first and then ivp4"


:D